### PR TITLE
Metadata support

### DIFF
--- a/goko/Cargo.toml
+++ b/goko/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goko"
-version = "0.3.3"
+version = "0.3.5"
 edition = "2018"
 
 description = "A lock-free, eventually consistent, concurrent covertree."
@@ -38,7 +38,7 @@ fxhash = "0.2.1"
 rayon = "1.3.1"
 hashbrown = { version = "0.8", features = ["rayon"] }
 crossbeam-channel = "0.4.2"
-pointcloud = { version = "0.3.0", path = "../pointcloud" }
+pointcloud = { version = "0.3.3", path = "../pointcloud" }
 #evmap = { git = "https://github.com/comath/rust-evmap" }
 smallvec = "1.4.1"
 type-map = "0.3.0"

--- a/goko/src/covertree/data_caches.rs
+++ b/goko/src/covertree/data_caches.rs
@@ -163,7 +163,7 @@ mod tests {
         }
         data.push(0.0);
 
-        let labels: Vec<u64> = data.iter().map(|x| if *x > 0.5 { 1 } else { 0 }).collect();
+        let labels: Vec<i64> = data.iter().map(|x| if *x > 0.5 { 1 } else { 0 }).collect();
 
         let point_cloud = DefaultLabeledCloud::<L2>::new_simple(data, 1, labels);
 
@@ -182,7 +182,7 @@ mod tests {
         }
         data.push(0.0);
 
-        let labels: Vec<u64> = data.iter().map(|x| if *x > 0.5 { 1 } else { 0 }).collect();
+        let labels: Vec<i64> = data.iter().map(|x| if *x > 0.5 { 1 } else { 0 }).collect();
 
         let point_cloud = Arc::new(DefaultLabeledCloud::<L2>::new_simple(data, 1, labels));
 
@@ -209,7 +209,7 @@ mod tests {
         }
         data.push(0.0);
 
-        let labels: Vec<u64> = data.iter().map(|x| if *x > 0.5 { 1 } else { 0 }).collect();
+        let labels: Vec<i64> = data.iter().map(|x| if *x > 0.5 { 1 } else { 0 }).collect();
 
         //data.sort_unstable_by(|a, b| (a).partial_cmp(&b).unwrap_or(Ordering::Equal));
         let point_cloud = DefaultLabeledCloud::<L2>::new_simple(data.clone(), 1, labels);

--- a/goko/src/covertree/node.rs
+++ b/goko/src/covertree/node.rs
@@ -29,6 +29,7 @@ use crate::NodeAddress;
 use pointcloud::*;
 use smallvec::SmallVec;
 use std::marker::PhantomData;
+use std::sync::Arc;
 /// The node children. This is a separate struct from the `CoverNode` to use the rust compile time type checking and
 /// `Option` data structure to ensure that all nodes with children are valid and cover their nested child.
 #[derive(Debug, Clone)]
@@ -75,8 +76,8 @@ impl<D: PointCloud> Clone for CoverNode<D> {
 
 impl<D: PointCloud + LabeledCloud> CoverNode<D> {
     /// If the node has a summary attached, this returns the summary.
-    pub fn label_summary(&self) -> Option<&D::LabelSummary> {
-        self.plugins.get::<NodeLabelSummary<D::LabelSummary>>().map(|c| c.summary.as_ref())
+    pub fn label_summary(&self) -> Option<Arc<SummaryCounter<D::LabelSummary>>> {
+        self.plugins.get::<NodeLabelSummary<D::LabelSummary>>().map(|c| Arc::clone(&c.summary))
     }
 }
 

--- a/goko/src/covertree/tree.rs
+++ b/goko/src/covertree/tree.rs
@@ -121,16 +121,13 @@ impl<D: PointCloud> Clone for CoverTreeReader<D> {
 impl<D: PointCloud + LabeledCloud> CoverTreeReader<D> {
     /// Reads the contents of a plugin, due to the nature of the plugin map we have to access it with a
     /// closure.
-    pub fn get_node_label_summary_and<F, S>(
+    pub fn get_node_label_summary(
         &self,
         node_address: (i32, PointIndex),
-        transform_fn: F,
-    ) -> Option<S>
-    where
-        F: Fn(&D::LabelSummary) -> S,
+    ) -> Option<Arc<SummaryCounter<D::LabelSummary>>>
     {
         self.layers[self.parameters.internal_index(node_address.0)]
-            .get_node_and(node_address.1, |n| n.label_summary().map(transform_fn))
+            .get_node_and(node_address.1, |n| n.label_summary())
             .flatten()
     }
 }
@@ -833,11 +830,10 @@ pub(crate) mod tests {
             layer.for_each_node(|_,n| println!("{:?}", n.label_summary()));
         }
 
-        reader.get_node_label_summary_and(reader.root_address(),|l| {
-            assert_eq!(l.items.len(),2);
-            assert_eq!(l.nones,0);
-            assert_eq!(l.errors,0);
-        });
+        let l = reader.get_node_label_summary(reader.root_address()).unwrap();
+        assert_eq!(l.summary.items.len(),2);
+        assert_eq!(l.nones,0);
+        assert_eq!(l.errors,0);
     }
 
     #[test]

--- a/goko/src/plugins/labels.rs
+++ b/goko/src/plugins/labels.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 #[derive(Debug, Default)]
 pub struct NodeLabelSummary<T: Summary> {
     /// The summary object, refenced counted to eliminate duplicates
-    pub summary: Arc<T>
+    pub summary: Arc<SummaryCounter<T>>
 }
 
 impl<T: Summary> Clone for NodeLabelSummary<T> {

--- a/pointcloud/Cargo.toml
+++ b/pointcloud/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pointcloud"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2018"
 
 description = "An accessor layer for goko"
@@ -31,12 +31,13 @@ rayon = "1.3.1"
 packed_simd = "0.3.3"
 glob = "0.3.0"
 fxhash = "0.2.1"
-hashbrown = { version = "0.8", features = ["rayon"] }
+hashbrown = { version = "0.8", features = ["rayon", "serde"] }
 serde_json = "1.0.56"
 serde = { version = "1.0.114", features = ["derive"] }
 flate2 = "1.0.16"
 rand = "0.7.3"
-smallvec = "1.3.0"
+smallvec = { version = "1.3.0", features = ["serde"] }
+num-traits = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["basetsd", "handleapi", "memoryapi", "minwindef", "std", "sysinfoapi"] }

--- a/pointcloud/Cargo.toml
+++ b/pointcloud/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pointcloud"
-version = "0.3.0"
+version = "0.3.3"
 edition = "2018"
 
 description = "An accessor layer for goko"

--- a/pointcloud/src/base_traits.rs
+++ b/pointcloud/src/base_traits.rs
@@ -338,7 +338,7 @@ impl<S:Summary> SummaryCounter<S> {
 
     /// how many samples labels errored out
     pub fn errors(&self) -> usize {
-        self.nones
+        self.errors
     }
 }
 
@@ -393,18 +393,27 @@ impl<D: PointCloud, L: LabelSet> LabeledCloud for SimpleLabeledCloud<D, L> {
     }
 }
 
-/*
+/// Enables the points in the underlying cloud to be named with strings. 
 pub trait NamedCloud: PointCloud {
-    fn name(&self, pi: PointIndex) -> Option<&PointName>;
-    fn index(&self, pn: PointName) -> Option<&PointIndex>;
+    /// Grabs the name of the point. 
+    /// Returns an error if the access errors out, and a None if the name is unknown
+    fn name(&self, pi: PointIndex) -> PointCloudResult<Option<&String>>;
+    /// Converts a name to an index you can use
+    fn index(&self, pn: &String) -> PointCloudResult<&PointIndex>;
+    /// Gather's all valid known names
     fn names(&self) -> Vec<PointName>;
 }
 
+/// Allows for expensive metadata, this is identical to the label trait, but enables slower update
 pub trait MetaCloud: PointCloud {
+    /// Underlying metadata
     type Metadata: ?Sized;
+    /// A summary of the underlying metadata
     type MetaSummary: Summary<Label = Self::Metadata>;
 
-    fn metadata(&self, pn: PointIndex) -> PointCloudResult<&Self::Metadata>;
-    fn metasummary(&self, pns: &[PointIndex]) -> PointCloudResult<Self::MetaSummary>;
+    /// Expensive metadata object for the sample
+    fn metadata(&self, pn: PointIndex) -> PointCloudResult<Option<&Self::Metadata>>;
+    /// Expensive metadata summary over the samples
+    fn metasummary(&self, pns: &[PointIndex]) -> PointCloudResult<SummaryCounter<Self::MetaSummary>>;
 }
-*/
+

--- a/pointcloud/src/data_sources/memmap_ram.rs
+++ b/pointcloud/src/data_sources/memmap_ram.rs
@@ -209,7 +209,7 @@ pub mod tests {
         .unwrap();
         let labels = SmallIntLabels::new(
             (0..count)
-                .map(|i| i as u64)
+                .map(|i| i as i64)
                 .collect(),
             None,
         );

--- a/pointcloud/src/glued_data_cloud.rs
+++ b/pointcloud/src/glued_data_cloud.rs
@@ -92,8 +92,8 @@ impl<D: LabeledCloud> LabeledCloud for HashGluedCloud<D> {
         let (i, j) = self.get_address(pn)?;
         self.data_sources[i].label(j)
     }
-    fn label_summary(&self, pns: &[PointIndex]) -> PointCloudResult<Self::LabelSummary> {
-        let mut summary = Self::LabelSummary::default();
+    fn label_summary(&self, pns: &[PointIndex]) -> PointCloudResult<SummaryCounter<Self::LabelSummary>> {
+        let mut summary = SummaryCounter::<Self::LabelSummary>::default();
         for pn in pns {
             let (i, j) = self.get_address(*pn)?;
             summary.add(self.data_sources[i].label(j));
@@ -209,7 +209,7 @@ mod tests {
         println!("{:?}", label_summary);
         assert_eq!(label_summary.nones, 0);
         assert_eq!(label_summary.errors, 0);
-        assert_eq!(label_summary.items[0], (1,5));
+        assert_eq!(label_summary.summary.items[0], (1,5));
     }
 
     #[test]

--- a/pointcloud/src/lib.rs
+++ b/pointcloud/src/lib.rs
@@ -56,7 +56,7 @@ pub type DefaultCloud<M> = DataRam<M>;
 
 impl<M: Metric> DefaultLabeledCloud<M> {
     /// Simple way of gluing together the most common data source
-    pub fn new_simple(data: Vec<f32>, dim: usize, labels: Vec<u64>) -> DefaultLabeledCloud<M> {
+    pub fn new_simple(data: Vec<f32>, dim: usize, labels: Vec<i64>) -> DefaultLabeledCloud<M> {
         SimpleLabeledCloud::new(
             DataRam::<M>::new(data, dim).unwrap(),
             SmallIntLabels::new(labels, None),

--- a/pointcloud/src/loaders/csv_loaders.rs
+++ b/pointcloud/src/loaders/csv_loaders.rs
@@ -54,7 +54,7 @@ fn read_csv<P: AsRef<Path> + std::fmt::Debug, R: Read>(
                 } else {
                     mask.push(false);
                 }
-                labels.push(val as u64);
+                labels.push(val);
             }
             None => {
                 labels.push(0);

--- a/pointcloud/src/pc_errors.rs
+++ b/pointcloud/src/pc_errors.rs
@@ -42,7 +42,7 @@ pub enum PointCloudError {
     /// You passes unsorted indexes into a function that required sorted indexes
     NotSorted,
     /// Most common error, the given point name isn't present in the training data
-    NameNotInTree(String),
+    NameNotInCloud(String),
     /// IO error when opening files
     IoError(io::Error),
     /// Parsing error when loading a CSV file
@@ -63,7 +63,7 @@ impl fmt::Display for PointCloudError {
             PointCloudError::DataAccessError { .. } => {
                 write!(f, "there was an issue grabbing a data point or label")
             }
-            PointCloudError::NameNotInTree { .. } => {
+            PointCloudError::NameNotInCloud { .. } => {
                 write!(f, "there was an issue grabbing a name from the known names")
             }
             PointCloudError::NodeNestingError { .. } => {
@@ -88,7 +88,7 @@ impl Error for PointCloudError {
             PointCloudError::DataAccessError { .. } => {
                 "there was an issue grabbing a data point or label"
             }
-            PointCloudError::NameNotInTree { .. } => {
+            PointCloudError::NameNotInCloud { .. } => {
                 "there was an issue grabbing a name from the known names"
             }
             PointCloudError::NodeNestingError { .. } => {
@@ -106,7 +106,7 @@ impl Error for PointCloudError {
             PointCloudError::IoError(ref e) => Some(e),
             PointCloudError::ParsingError(ref e) => Some(e),
             PointCloudError::DataAccessError { .. } => None,
-            PointCloudError::NameNotInTree { .. } => None,
+            PointCloudError::NameNotInCloud { .. } => None,
             PointCloudError::NodeNestingError { .. } => None,
             PointCloudError::MetricError { .. } => None,
             PointCloudError::NotSorted { .. } => None,

--- a/pygoko/src/node.rs
+++ b/pygoko/src/node.rs
@@ -164,14 +164,13 @@ impl PyNode {
         let gil = GILGuard::acquire();
         let py = gil.python();
         let dict = PyDict::new(py);
-        let py_result = self.tree.get_node_label_summary_and::<_,PyResult<()>>(self.address, |s| {
-            dict.set_item("errors", s.errors)?;
-            dict.set_item("nones", s.nones)?;
-            dict.set_item("items", s.items.to_vec())?;
-            Ok(())
-        });
-        match py_result {
-            Some(res) => {res?; Ok(Some(dict.into()))},
+        match self.tree.get_node_label_summary(self.address) {
+            Some(s) => {
+                dict.set_item("errors", s.errors)?;
+                dict.set_item("nones", s.nones)?;
+                dict.set_item("items", s.summary.items.to_vec())?;
+                Ok(Some(dict.into()))
+            }
             None => Ok(None),
         }
     }

--- a/pygoko/src/tree.rs
+++ b/pygoko/src/tree.rs
@@ -89,11 +89,11 @@ impl CoverTree {
         self.metric = metric_name;
     }
 
-    pub fn fit(&mut self, data: Option<&PyArray2<f32>>, labels: Option<&PyArray1<u64>>) -> PyResult<()> {
+    pub fn fit(&mut self, data: Option<&PyArray2<f32>>, labels: Option<&PyArray1<i64>>) -> PyResult<()> {
         let point_cloud = if let Some(data) = data {
             let len = data.shape()[0];
             let data_dim = data.shape()[1];
-            let my_labels: Vec<u64> = match labels {
+            let my_labels: Vec<i64> = match labels {
                 Some(labels) => {
                     Vec::from(labels.readonly().as_slice().unwrap())
                 }


### PR DESCRIPTION
Changed the summary of labels to be a summary of the underlying type, wrapped with a joint `Result::Err` and `Option::None` counter. This greatly simplifies the implementation of the trait `Summary` as the individual implementations of the summaries do not need to count the `Nones` and `Errors`, but makes accessing them a little irritating.  

This also adds `NamedCloud` and `MetaCloud` traits. A named cloud has a string associated to some of the point in the cloud. The `NamedCloud` trait provides a means of accessing the name. A `MetaCloud` is identical to a `LabeledCloud`, but is separated as this is meant to be the expensive more general version. We also will limit `LabeledCloud` to certain types of labels once we have a better idea of the plugins we want to feed the labels to.